### PR TITLE
Update gmt.r

### DIFF
--- a/R/gmt.r
+++ b/R/gmt.r
@@ -51,7 +51,8 @@ write.GMT <- function(gmt, filename) {
     if (!is.GMT(gmt)) stop("gmt is not a valid GMT object")
     sink(filename)
     for (term in gmt) {
-        cat(term$id, term$name, paste(term$genes, collapse="\t"), "\n", sep="\t")
+        cat(term$id, term$name, paste(term$genes, collapse = "\t"), sep = "\t")
+        cat("\n")
     }
     sink()
 }


### PR DESCRIPTION
remove the ending tab for each line when writing the gmt file so that the written gmt file format is consistent with the one downloaded from msigdb.